### PR TITLE
Fix registration test URL

### DIFF
--- a/auth_service/tests/test_unit.py
+++ b/auth_service/tests/test_unit.py
@@ -16,5 +16,5 @@ from auth_service.main import app
 )
 async def test_registration(payload,expected_status):
     async with AsyncClient(transport=ASGITransport(app = app)) as ac:
-        response = await ac.post("http://localhost:800/regist0ration", json=payload)
+        response = await ac.post("http://localhost:800/registration", json=payload)
         assert response.status_code == expected_status


### PR DESCRIPTION
## Summary
- adjust the POST URL in auth_service tests to use `/registration` endpoint

## Testing
- `pytest -q` *(fails: TypeError in redis.py)*

------
https://chatgpt.com/codex/tasks/task_e_6856f8a344388324a30c40e8078e8960