### PR TITLE
Add feed page and connect auth forms

### DIFF
--- a/frontend/src/Feed.css
+++ b/frontend/src/Feed.css
@@ -1,0 +1,23 @@
+.feed-page {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  background: #ffffff;
+}
+
+.cash-button {
+  background: #4caf50;
+  color: #fff;
+  padding: 1.2rem 2rem;
+  font-size: 1.5rem;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.cash-display {
+  font-size: 3rem;
+  margin-top: 1rem;
+}

--- a/frontend/src/Feed.jsx
+++ b/frontend/src/Feed.jsx
@@ -1,0 +1,21 @@
+import { useState } from 'react'
+import './Feed.css'
+
+function Feed() {
+  const [showCash, setShowCash] = useState(false)
+
+  const handleClick = () => {
+    setShowCash(true)
+  }
+
+  return (
+    <div className="feed-page">
+      <button className="cash-button" onClick={handleClick}>
+        Сделать кэшик
+      </button>
+      {showCash && <div className="cash-display">💵💵💵</div>}
+    </div>
+  )
+}
+
+export default Feed

--- a/frontend/src/Login.jsx
+++ b/frontend/src/Login.jsx
@@ -1,14 +1,25 @@
 import { useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import './AuthForm.css'
 
 function Login() {
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
+  const navigate = useNavigate()
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault()
-    // TODO: handle login
+    const response = await fetch('/entrance', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ login: username, password }),
+    })
+    if (response.ok) {
+      navigate('/feed')
+    } else {
+      const data = await response.json().catch(() => ({}))
+      alert(data.detail || 'Login failed')
+    }
   }
 
   return (

--- a/frontend/src/Registration.jsx
+++ b/frontend/src/Registration.jsx
@@ -1,19 +1,30 @@
 import { useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import './AuthForm.css'
 
 function Registration() {
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
   const [confirm, setConfirm] = useState('')
+  const navigate = useNavigate()
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault()
     if (password !== confirm) {
       alert('Passwords do not match')
       return
     }
-    // TODO: handle registration
+    const response = await fetch('/registration', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ login: username, password, confir_password: confirm }),
+    })
+    if (response.ok) {
+      navigate('/feed')
+    } else {
+      const data = await response.json().catch(() => ({}))
+      alert(data.detail || 'Registration failed')
+    }
   }
 
   return (

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -4,6 +4,7 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import App from './App.jsx'
 import Login from './Login.jsx'
 import Registration from './Registration.jsx'
+import Feed from './Feed.jsx'
 import './index.css'
 
 createRoot(document.getElementById('root')).render(
@@ -13,6 +14,7 @@ createRoot(document.getElementById('root')).render(
         <Route path="/" element={<App />} />
         <Route path="/login" element={<Login />} />
         <Route path="/registration" element={<Registration />} />
+        <Route path="/feed" element={<Feed />} />
       </Routes>
     </BrowserRouter>
   </StrictMode>,


### PR DESCRIPTION
## Summary
- send login credentials to `/entrance`
- send registration data to `/registration`
- redirect to `/feed` after success
- add new Feed page with cash button
- link feed page in router

## Testing
- `pytest -q` *(fails: missing env vars for redis)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6856fd240ecc83248c25af7eaf1fc65d