### PR TITLE
Add user profile dropdown menu in feed

### DIFF
--- a/frontend/src/Feed.css
+++ b/frontend/src/Feed.css
@@ -54,12 +54,14 @@
 .profile-header {
   display: flex;
   justify-content: flex-end;
+  position: relative;
 }
 
 .profile-block {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  cursor: pointer;
 }
 
 .avatar {
@@ -87,6 +89,33 @@
   border: 1px dashed #555;
   border-radius: 8px;
   background: #1e1e1e;
+}
+
+.profile-menu {
+  position: absolute;
+  top: 60px;
+  right: 0;
+  background: #1e1e1e;
+  border: 1px solid #555;
+  border-radius: 8px;
+  padding: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  min-width: 150px;
+}
+
+.profile-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.profile-menu-item:hover {
+  background: #2c2c2c;
 }
 
 @media (max-width: 700px) {

--- a/frontend/src/Feed.jsx
+++ b/frontend/src/Feed.jsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import avatar from './assets/react.svg'
 import './Feed.css'
@@ -16,10 +16,14 @@ import {
   MarketIcon,
   FilesIcon,
   HelpIcon,
+  SettingsIcon,
+  LogoutIcon,
+  StatsIcon,
 } from './icons.jsx'
 
 function Feed() {
   const navigate = useNavigate()
+  const [menuOpen, setMenuOpen] = useState(false)
 
   useEffect(() => {
     const checkAuth = async () => {
@@ -82,11 +86,27 @@ function Feed() {
       </aside>
       <main className="main-area">
         <header className="profile-header">
-          <div className="profile-block">
+          <div className="profile-block" onClick={() => setMenuOpen((v) => !v)}>
             <img src={avatar} alt="avatar" className="avatar" />
             <span className="name">Имя Пользователя</span>
             <span className="arrow">▼</span>
           </div>
+          {menuOpen && (
+            <div className="profile-menu">
+              <div className="profile-menu-item">
+                <SettingsIcon className="icon-svg" />
+                <span>Настройки</span>
+              </div>
+              <div className="profile-menu-item">
+                <LogoutIcon className="icon-svg" />
+                <span>Выход</span>
+              </div>
+              <div className="profile-menu-item">
+                <StatsIcon className="icon-svg" />
+                <span>Статистика</span>
+              </div>
+            </div>
+          )}
         </header>
         <section className="stories-placeholder" />
         <section className="feed-placeholder">

--- a/frontend/src/icons.jsx
+++ b/frontend/src/icons.jsx
@@ -104,3 +104,26 @@ export const HelpIcon = (props) => (
   </svg>
 )
 
+export const SettingsIcon = (props) => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" {...props}>
+    <circle cx="12" cy="12" r="3" />
+    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l0 0a2 2 0 1 1-2.83 2.83l0 0a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51v0a2 2 0 1 1-4 0v0a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l0 0a2 2 0 1 1-2.83-2.83l0 0a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h0a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l0 0a2 2 0 1 1 2.83-2.83l0 0a1.65 1.65 0 0 0 1.82.33h0a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v0a1.65 1.65 0 0 0 1 1.51h0a1.65 1.65 0 0 0 1.82-.33l0 0a2 2 0 1 1 2.83 2.83l0 0a1.65 1.65 0 0 0-.33 1.82v0a1.65 1.65 0 0 0 1.51 1h0a2 2 0 0 1 0 4h0a1.65 1.65 0 0 0-1.51 1z" />
+  </svg>
+)
+
+export const LogoutIcon = (props) => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" {...props}>
+    <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+    <polyline points="16 17 21 12 16 7" />
+    <line x1="21" y1="12" x2="9" y2="12" />
+  </svg>
+)
+
+export const StatsIcon = (props) => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" {...props}>
+    <line x1="18" y1="20" x2="18" y2="10" />
+    <line x1="12" y1="20" x2="12" y2="4" />
+    <line x1="6" y1="20" x2="6" y2="14" />
+  </svg>
+)
+


### PR DESCRIPTION
## Summary
- expand icon library with settings, logout and stats icons
- add dropdown menu to Feed page for user actions
- style new profile dropdown menu

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6858e22b272c8324ba58d18b64b17edb