### PR TITLE
Implement logout action

### DIFF
--- a/frontend/src/Feed.jsx
+++ b/frontend/src/Feed.jsx
@@ -54,6 +54,14 @@ function Feed() {
     checkAuth()
   }, [navigate])
 
+  const handleLogout = async () => {
+    await fetch('http://localhost:8000/logout', {
+      method: 'POST',
+      credentials: 'include',
+    })
+    navigate('/login')
+  }
+
   const menuItems = [
     { label: 'Профиль', Icon: ProfileIcon },
     { label: 'Лента', Icon: FeedIcon },
@@ -97,7 +105,7 @@ function Feed() {
                 <SettingsIcon className="icon-svg" />
                 <span>Настройки</span>
               </div>
-              <div className="profile-menu-item">
+              <div className="profile-menu-item" onClick={handleLogout}>
                 <LogoutIcon className="icon-svg" />
                 <span>Выход</span>
               </div>


### PR DESCRIPTION
## Summary
- add logout request handler in Feed page
- attach handler to logout menu item

## Testing
- `npm run lint`
- `pytest` *(fails: TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType')*

------
https://chatgpt.com/codex/tasks/task_e_6858ef290b24832498918e950d87ab62