### PR TITLE
Add profile page with form and routing

### DIFF
--- a/frontend/src/Feed.jsx
+++ b/frontend/src/Feed.jsx
@@ -63,7 +63,7 @@ function Feed() {
   }
 
   const menuItems = [
-    { label: 'Профиль', Icon: ProfileIcon },
+    { label: 'Профиль', Icon: ProfileIcon, onClick: () => navigate('/profile') },
     { label: 'Лента', Icon: FeedIcon },
     { label: 'Мессенджер', Icon: MessageIcon },
     { label: 'Звонки', Icon: PhoneIcon },
@@ -84,7 +84,11 @@ function Feed() {
         <nav>
           <ul className="menu">
             {menuItems.map((item) => (
-              <li key={item.label} className="menu-item">
+              <li
+                key={item.label}
+                className="menu-item"
+                onClick={item.onClick}
+              >
                 <item.Icon className="icon-svg" />
                 <span className="label">{item.label}</span>
               </li>

--- a/frontend/src/Profile.css
+++ b/frontend/src/Profile.css
@@ -1,0 +1,113 @@
+.profile-page {
+  display: flex;
+  min-height: 100vh;
+  background: #1e1e1e;
+  color: #fff;
+  font-family: system-ui, sans-serif;
+}
+
+.sidebar {
+  width: 400px;
+  flex-shrink: 0;
+  background: #1e1e1e;
+  padding: 1rem;
+  margin-left: -250px;
+}
+
+.menu {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.menu-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.menu-item:hover {
+  background: #2c2c2c;
+}
+
+.icon-svg {
+  width: 20px;
+  height: 20px;
+}
+
+.main-area {
+  flex: 1;
+  display: flex;
+  align-items: flex-start;
+  gap: 2rem;
+  padding: 1rem;
+  margin-left: -150px;
+}
+
+.photo-question {
+  position: relative;
+}
+
+.profile-photo {
+  width: 150px;
+  height: 150px;
+  border-radius: 50%;
+}
+
+.question {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 4rem;
+  color: #fff;
+  pointer-events: none;
+}
+
+.profile-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  width: 250px;
+}
+
+.profile-form input,
+.profile-form select {
+  padding: 0.5rem;
+  font-size: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  color: #1e1e1e;
+}
+
+.profile-form button {
+  background: #FFD54F;
+  color: #333;
+  border: none;
+  padding: 0.6em 1.2em;
+  font-size: 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.25s;
+}
+
+.profile-form button:hover {
+  background: #e6c347;
+}
+
+@media (max-width: 700px) {
+  .sidebar {
+    width: 200px;
+    margin-left: -250px;
+  }
+}

--- a/frontend/src/Profile.jsx
+++ b/frontend/src/Profile.jsx
@@ -1,0 +1,148 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import avatar from './assets/react.svg'
+import './Profile.css'
+import {
+  ProfileIcon,
+  FeedIcon,
+  MessageIcon,
+  PhoneIcon,
+  FriendsIcon,
+  CommunitiesIcon,
+  PhotoIcon,
+  MusicIcon,
+  VideoIcon,
+  GameIcon,
+  MarketIcon,
+  FilesIcon,
+  HelpIcon,
+} from './icons.jsx'
+
+function Profile() {
+  const navigate = useNavigate()
+  const [formData, setFormData] = useState({
+    nickname: '',
+    name: '',
+    login: '',
+    age: '',
+    city: '',
+    gender: '',
+  })
+
+  const menuItems = [
+    { label: 'Профиль', Icon: ProfileIcon, onClick: () => navigate('/profile') },
+    { label: 'Лента', Icon: FeedIcon, onClick: () => navigate('/feed') },
+    { label: 'Мессенджер', Icon: MessageIcon },
+    { label: 'Звонки', Icon: PhoneIcon },
+    { label: 'Друзья', Icon: FriendsIcon },
+    { label: 'Сообщества', Icon: CommunitiesIcon },
+    { label: 'Фото', Icon: PhotoIcon },
+    { label: 'Музыка', Icon: MusicIcon },
+    { label: 'Видео', Icon: VideoIcon },
+    { label: 'Игры', Icon: GameIcon },
+    { label: 'Маркет', Icon: MarketIcon },
+    { label: 'Файлы', Icon: FilesIcon },
+    { label: 'Помощь', Icon: HelpIcon },
+  ]
+
+  const handleChange = (e) => {
+    const { name, value } = e.target
+    setFormData((prev) => ({ ...prev, [name]: value }))
+  }
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    if (!formData.age || isNaN(Number(formData.age))) {
+      alert('Возраст должен быть числом')
+      return
+    }
+    await fetch('http://localhost:8000/profile', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(formData),
+    })
+  }
+
+  return (
+    <div className="profile-page">
+      <aside className="sidebar">
+        <nav>
+          <ul className="menu">
+            {menuItems.map((item) => (
+              <li
+                key={item.label}
+                className="menu-item"
+                onClick={item.onClick}
+              >
+                <item.Icon className="icon-svg" />
+                <span className="label">{item.label}</span>
+              </li>
+            ))}
+          </ul>
+        </nav>
+      </aside>
+      <main className="main-area">
+        <div className="photo-question">
+          <img src={avatar} alt="avatar" className="profile-photo" />
+          <div className="question">?</div>
+        </div>
+        <form className="profile-form" onSubmit={handleSubmit}>
+          <input
+            type="text"
+            name="nickname"
+            placeholder="Ник"
+            value={formData.nickname}
+            onChange={handleChange}
+            required
+          />
+          <input
+            type="text"
+            name="name"
+            placeholder="Имя"
+            value={formData.name}
+            onChange={handleChange}
+            required
+          />
+          <input
+            type="text"
+            name="login"
+            placeholder="Логин"
+            value={formData.login}
+            onChange={handleChange}
+            required
+          />
+          <input
+            type="number"
+            name="age"
+            placeholder="Возраст"
+            value={formData.age}
+            onChange={handleChange}
+            required
+          />
+          <input
+            type="text"
+            name="city"
+            placeholder="Город"
+            value={formData.city}
+            onChange={handleChange}
+            required
+          />
+          <select
+            name="gender"
+            value={formData.gender}
+            onChange={handleChange}
+            required
+          >
+            <option value="">Пол</option>
+            <option value="male">Мужской</option>
+            <option value="female">Женский</option>
+            <option value="other">Другое</option>
+          </select>
+          <button type="submit">Заполнить профиль</button>
+        </form>
+      </main>
+    </div>
+  )
+}
+
+export default Profile

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -5,6 +5,7 @@ import App from './App.jsx'
 import Login from './Login.jsx'
 import Registration from './Registration.jsx'
 import Feed from './Feed.jsx'
+import Profile from './Profile.jsx'
 import './index.css'
 
 createRoot(document.getElementById('root')).render(
@@ -15,6 +16,7 @@ createRoot(document.getElementById('root')).render(
         <Route path="/login" element={<Login />} />
         <Route path="/registration" element={<Registration />} />
         <Route path="/feed" element={<Feed />} />
+        <Route path="/profile" element={<Profile />} />
       </Routes>
     </BrowserRouter>
   </StrictMode>,


### PR DESCRIPTION
## Summary
- create new Profile page component with profile form
- add CSS styles for the profile page
- add route for `/profile`
- allow navigating to profile from feed

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6860315e0dd483248926e77ac44a00e3