### PR TITLE
Add profile edit modal

### DIFF
--- a/frontend/src/Profile.css
+++ b/frontend/src/Profile.css
@@ -177,3 +177,48 @@ body {
         width: 70%;
     }
 }
+
+.modal-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.6);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 50;
+}
+
+.modal {
+    background: var(--surface-dark);
+    padding: 1.5rem;
+    border-radius: 8px;
+    width: 90%;
+    max-width: 400px;
+    position: relative;
+}
+
+.close-btn {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    background: none;
+    border: none;
+    font-size: 1.5rem;
+    color: #888;
+    cursor: pointer;
+}
+
+.form-group {
+    margin-bottom: 0.75rem;
+    display: flex;
+    flex-direction: column;
+}
+
+.save-btn {
+    background-color: var(--primary-dark);
+    color: #fff;
+    border: none;
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    cursor: pointer;
+}

--- a/frontend/src/Profile.jsx
+++ b/frontend/src/Profile.jsx
@@ -14,6 +14,7 @@ import {
 function Profile() {
   const navigate = useNavigate()
   const [menuOpen, setMenuOpen] = useState(false)
+  const [showForm, setShowForm] = useState(false)
   const fileInputRef = useRef(null)
 
   const menuItems = [
@@ -125,7 +126,10 @@ function Profile() {
                   <span className="info-value">Мужской</span>
                 </div>
               </div>
-              <button className="edit-profile-btn">
+              <button
+                className="edit-profile-btn"
+                onClick={() => setShowForm(true)}
+              >
                 <i className="fas fa-edit" /> Заполнить профиль
               </button>
             </div>
@@ -176,6 +180,51 @@ function Profile() {
           </button>
         </div>
       </div>
+      {showForm && (
+        <div className="modal-overlay">
+          <div className="modal">
+            <button className="close-btn" onClick={() => setShowForm(false)}>
+              &times;
+            </button>
+            <form id="profileForm">
+              <div className="form-group">
+                <label htmlFor="username">Никнейм:</label>
+                <input type="text" id="username" name="username" />
+              </div>
+              <div className="form-group">
+                <label htmlFor="firstName">Имя:</label>
+                <input type="text" id="firstName" name="firstName" />
+              </div>
+              <div className="form-group">
+                <label htmlFor="lastName">Фамилия:</label>
+                <input type="text" id="lastName" name="lastName" />
+              </div>
+              <div className="form-group">
+                <label htmlFor="middleName">Отчество:</label>
+                <input type="text" id="middleName" name="middleName" />
+              </div>
+              <div className="form-group">
+                <label htmlFor="age">Возраст:</label>
+                <input type="number" id="age" name="age" />
+              </div>
+              <div className="form-group">
+                <label htmlFor="city">Город:</label>
+                <input type="text" id="city" name="city" />
+              </div>
+              <div className="form-group">
+                <label>Пол:</label>
+                <div>
+                  <input type="radio" id="male" name="gender" value="Мужской" />
+                  <label htmlFor="male">Мужской</label>
+                  <input type="radio" id="female" name="gender" value="Женский" />
+                  <label htmlFor="female">Женский</label>
+                </div>
+              </div>
+              <button type="submit" className="save-btn">Сохранить</button>
+            </form>
+          </div>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add a profile editing modal that opens from `Заполнить профиль`
- include close button and form fields
- style modal overlay and form

## Testing
- `npm run lint`
- `npm run build`
- `pytest` *(fails: TypeError in auth_service)*

------
https://chatgpt.com/codex/tasks/task_e_6867bd8085a88324b9ba4f6a7a724a27