### PR TITLE
Add JWT decode on client and dynamic profile routing

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "jwt-decode": "^4.0.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^6.30.1"
@@ -2199,6 +2200,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/keyv": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router-dom": "^6.30.1"
+    "react-router-dom": "^6.30.1",
+    "jwt-decode": "^4.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/frontend/src/Feed.jsx
+++ b/frontend/src/Feed.jsx
@@ -1,5 +1,16 @@
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import jwtDecode from 'jwt-decode'
+
+const getUserIdFromToken = () => {
+  const match = document.cookie.match(/access_token=([^;]+)/)
+  if (!match) return null
+  try {
+    return jwtDecode(decodeURIComponent(match[1])).sub
+  } catch {
+    return null
+  }
+}
 import {
   ProfileIcon,
   FeedIcon,
@@ -61,7 +72,14 @@ function Feed() {
   }
 
   const menuItems = [
-    { label: 'Профиль', Icon: ProfileIcon, onClick: () => navigate('/profile') },
+    {
+      label: 'Профиль',
+      Icon: ProfileIcon,
+      onClick: () => {
+        const id = getUserIdFromToken()
+        if (id) navigate(`/profile/${id}`)
+      },
+    },
     { label: 'Лента', Icon: FeedIcon },
     { label: 'Мессенджер', Icon: MessageIcon },
     { label: 'Помощь', Icon: HelpIcon },

--- a/frontend/src/Profile.jsx
+++ b/frontend/src/Profile.jsx
@@ -1,5 +1,16 @@
 import { useState, useRef, useEffect } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
+import jwtDecode from 'jwt-decode'
+
+const getUserIdFromToken = () => {
+  const match = document.cookie.match(/access_token=([^;]+)/)
+  if (!match) return null
+  try {
+    return jwtDecode(decodeURIComponent(match[1])).sub
+  } catch {
+    return null
+  }
+}
 import './Profile.css'
 import {
   ProfileIcon,
@@ -13,6 +24,8 @@ import {
 
 function Profile() {
   const navigate = useNavigate()
+  const { userId } = useParams()
+  const decodedId = getUserIdFromToken()
   const [menuOpen, setMenuOpen] = useState(false)
   const [showForm, setShowForm] = useState(false)
 
@@ -28,14 +41,13 @@ function Profile() {
 
   useEffect(() => {
     const fetchProfile = async () => {
-      let userId
-      const res = await fetch('http://localhost:8000/protected', {
+      let id = userId || decodedId
+
+      const auth = await fetch('http://localhost:8000/protected', {
         credentials: 'include',
       })
-      if (res.ok) {
-        const data = await res.json()
-        userId = data.user_id
-      } else {
+
+      if (!auth.ok) {
         const refreshRes = await fetch('http://localhost:8000/refresh', {
           credentials: 'include',
         })
@@ -43,18 +55,21 @@ function Profile() {
           navigate('/login')
           return
         }
-        const verify = await fetch('http://localhost:8000/protected', {
-          credentials: 'include',
-        })
-        if (!verify.ok) {
+      }
+
+      if (!id) {
+        id = getUserIdFromToken()
+        if (!id) {
           navigate('/login')
           return
         }
-        const verifyData = await verify.json()
-        userId = verifyData.user_id
       }
 
-      const profileRes = await fetch(`http://localhost:8001/profile/${userId}`, {
+      if (!userId && id) {
+        navigate(`/profile/${id}`, { replace: true })
+      }
+
+      const profileRes = await fetch(`http://localhost:8001/profile/${id}`, {
         credentials: 'include',
       })
       if (profileRes.ok) {
@@ -70,10 +85,17 @@ function Profile() {
     }
 
     fetchProfile()
-  }, [navigate])
+  }, [navigate, userId, decodedId])
 
   const menuItems = [
-    { label: 'Профиль', Icon: ProfileIcon, onClick: () => navigate('/profile') },
+    {
+      label: 'Профиль',
+      Icon: ProfileIcon,
+      onClick: () => {
+        const id = getUserIdFromToken()
+        if (id) navigate(`/profile/${id}`)
+      },
+    },
     { label: 'Лента', Icon: FeedIcon, onClick: () => navigate('/feed') },
     { label: 'Мессенджер', Icon: MessageIcon },
     { label: 'Помощь', Icon: HelpIcon },

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -16,7 +16,7 @@ createRoot(document.getElementById('root')).render(
         <Route path="/login" element={<Login />} />
         <Route path="/registration" element={<Registration />} />
         <Route path="/feed" element={<Feed />} />
-        <Route path="/profile" element={<Profile />} />
+        <Route path="/profile/:userId" element={<Profile />} />
       </Routes>
     </BrowserRouter>
   </StrictMode>,


### PR DESCRIPTION
## Summary
- decode `access_token` JWT in the frontend
- navigate to dynamic `/profile/:userId` route using the decoded id
- use decoded id when fetching profile data
- install `jwt-decode` dependency

## Testing
- `npm --prefix frontend install`
- `pytest -q` *(fails: TypeError in `test_registration_success`)*

------
https://chatgpt.com/codex/tasks/task_e_686a7c1434288324b9bee9032d78d8d5