### PR TITLE
Fix React build issue and extend profile page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Python cache
+**/__pycache__/
+*.pyc
+
+# Node
+frontend/node_modules/
+
+# Build
+frontend/dist/
+
+# Others
+.env
+

--- a/frontend/src/Feed.jsx
+++ b/frontend/src/Feed.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import jwtDecode from 'jwt-decode'
+import { jwtDecode } from 'jwt-decode'
 
 const getUserIdFromToken = () => {
   const match = document.cookie.match(/access_token=([^;]+)/)

--- a/frontend/src/Profile.css
+++ b/frontend/src/Profile.css
@@ -222,3 +222,25 @@ body {
     border-radius: 4px;
     cursor: pointer;
 }
+
+.friend-actions {
+    display: flex;
+    gap: 0.5rem;
+    margin-top: 1rem;
+}
+
+.add-friend-btn,
+.send-message-btn {
+    background-color: var(--primary-dark);
+    color: #fff;
+    border: none;
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background-color 0.3s;
+}
+
+.add-friend-btn:hover,
+.send-message-btn:hover {
+    background-color: #a370d8;
+}

--- a/frontend/src/Profile.jsx
+++ b/frontend/src/Profile.jsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
-import jwtDecode from 'jwt-decode'
+import { jwtDecode } from 'jwt-decode'
 
 const getUserIdFromToken = () => {
   const match = document.cookie.match(/access_token=([^;]+)/)
@@ -236,6 +236,10 @@ function Profile() {
           <button className="create-post-btn">
             <i className="fas fa-plus-circle" /> Создать пост
           </button>
+          <div className="friend-actions">
+            <button className="add-friend-btn">Добавить в друзья</button>
+            <button className="send-message-btn">Написать сообщение</button>
+          </div>
         </div>
       </main>
 


### PR DESCRIPTION
## Summary
- fix import from jwt-decode so build succeeds
- add friend actions to profile page and styles
- add `.gitignore` for caches and build artifacts

## Testing
- `npm run build`
- `pytest -q` *(fails: TypeError: object JSONResponse can't be used in 'await' expression)*

------
https://chatgpt.com/codex/tasks/task_e_686a807ecce88324afb19dabb03a6b82