### PR TITLE
Hide editing on other profiles

### DIFF
--- a/frontend/src/Profile.jsx
+++ b/frontend/src/Profile.jsx
@@ -26,6 +26,7 @@ function Profile() {
   const navigate = useNavigate()
   const { userId } = useParams()
   const decodedId = getUserIdFromToken()
+  const isOwnProfile = !userId || userId === decodedId
   const [menuOpen, setMenuOpen] = useState(false)
   const [showForm, setShowForm] = useState(false)
 
@@ -215,16 +216,20 @@ function Profile() {
               <div className="photo-placeholder">
                 <i className="fas fa-user-circle" />
               </div>
-              <input
-                type="file"
-                accept="image/*"
-                ref={fileInputRef}
-                className="hidden"
-                onChange={handleFileChange}
-              />
-              <button className="upload-btn" onClick={handleUploadClick}>
-                <i className="fas fa-camera" /> Загрузить фото
-              </button>
+              {isOwnProfile && (
+                <>
+                  <input
+                    type="file"
+                    accept="image/*"
+                    ref={fileInputRef}
+                    className="hidden"
+                    onChange={handleFileChange}
+                  />
+                  <button className="upload-btn" onClick={handleUploadClick}>
+                    <i className="fas fa-camera" /> Загрузить фото
+                  </button>
+                </>
+              )}
             </div>
             <div className="profile-info">
               <h2>Профиль пользователя</h2>
@@ -258,21 +263,26 @@ function Profile() {
                   <span className="info-value">{gender}</span>
                 </div>
               </div>
-              <button
-                className="edit-profile-btn"
-                onClick={openForm}
-              >
-                <i className="fas fa-edit" /> Заполнить профиль
-              </button>
+              {isOwnProfile && (
+                <button
+                  className="edit-profile-btn"
+                  onClick={openForm}
+                >
+                  <i className="fas fa-edit" /> Заполнить профиль
+                </button>
+              )}
             </div>
           </div>
-          <button className="create-post-btn">
-            <i className="fas fa-plus-circle" /> Создать пост
-          </button>
-          <div className="friend-actions">
-            <button className="add-friend-btn">Добавить в друзья</button>
-            <button className="send-message-btn">Написать сообщение</button>
-          </div>
+          {isOwnProfile ? (
+            <button className="create-post-btn">
+              <i className="fas fa-plus-circle" /> Создать пост
+            </button>
+          ) : (
+            <div className="friend-actions">
+              <button className="add-friend-btn">Добавить в друзья</button>
+              <button className="send-message-btn">Написать сообщение</button>
+            </div>
+          )}
         </div>
       </main>
 


### PR DESCRIPTION
## Summary
- conditionally detect when viewing own profile
- hide photo upload, post creation and edit buttons for other users
- keep friend actions when browsing other profiles

## Testing
- `npm run lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686aaacf21f483248ac0773eac8b62ac