### PR TITLE
Add article and friend actions on own profile

### DIFF
--- a/frontend/src/Profile.css
+++ b/frontend/src/Profile.css
@@ -46,7 +46,7 @@ body {
     padding: 0 1rem;
 }
 
-.create-post-btn {
+.write-article-btn {
     background-color: var(--primary-dark);
     color: white;
     border: none;
@@ -59,7 +59,7 @@ body {
     transition: all 0.3s;
 }
 
-.create-post-btn:hover {
+.write-article-btn:hover {
     background-color: #a370d8;
     transform: translateY(-2px);
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);

--- a/frontend/src/Profile.jsx
+++ b/frontend/src/Profile.jsx
@@ -263,26 +263,25 @@ function Profile() {
                   <span className="info-value">{gender}</span>
                 </div>
               </div>
-              {isOwnProfile && (
-                <button
-                  className="edit-profile-btn"
-                  onClick={openForm}
-                >
-                  <i className="fas fa-edit" /> Заполнить профиль
-                </button>
-              )}
+              {isOwnProfile ? (
+                <>
+                  <button
+                    className="edit-profile-btn"
+                    onClick={openForm}
+                  >
+                    <i className="fas fa-edit" /> Заполнить профиль
+                  </button>
+                  <button className="write-article-btn">
+                    <i className="fas fa-pen" /> Написать статью
+                  </button>
+                </>
+              ) : null}
             </div>
           </div>
-          {isOwnProfile ? (
-            <button className="create-post-btn">
-              <i className="fas fa-plus-circle" /> Создать пост
-            </button>
-          ) : (
-            <div className="friend-actions">
-              <button className="add-friend-btn">Добавить в друзья</button>
-              <button className="send-message-btn">Написать сообщение</button>
-            </div>
-          )}
+          <div className="friend-actions">
+            <button className="add-friend-btn">Добавить в друзья</button>
+            <button className="send-message-btn">Написать сообщение</button>
+          </div>
         </div>
       </main>
 


### PR DESCRIPTION
## Summary
- allow profile page to always show friend action buttons
- add new "write article" action under "fill profile" when viewing own profile
- rename CSS class for article button

## Testing
- `npm ci`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686aad1ec2208324aef302ac365ab56e