### PR TITLE
Improve token refresh UX

### DIFF
--- a/frontend/src/Feed.jsx
+++ b/frontend/src/Feed.jsx
@@ -27,14 +27,16 @@ async function getUserId() {
     const { user_id } = await auth.json()
     return user_id
   }
+
   const refreshRes = await fetch('http://localhost:8001/refresh', {
     credentials: 'include',
   })
   if (!refreshRes.ok) return null
+
   const verify = await fetch('http://localhost:8001/protected', {
     credentials: 'include',
   })
-  if (!verify.ok) return null
+  if (!verify.ok) return undefined
   const { user_id } = await verify.json()
   return user_id
 }
@@ -47,11 +49,11 @@ function Feed() {
   useEffect(() => {
     const checkAuth = async () => {
       const id = await getUserId()
-      if (!id) {
+      if (id === null) {
         navigate('/login')
         return
       }
-      setCurrentUserId(id)
+      if (id !== undefined) setCurrentUserId(id)
     }
 
     checkAuth()

--- a/frontend/src/Profile.jsx
+++ b/frontend/src/Profile.jsx
@@ -26,7 +26,7 @@ async function getUserId() {
   const verify = await fetch('http://localhost:8001/protected', {
     credentials: 'include',
   })
-  if (!verify.ok) return null
+  if (!verify.ok) return undefined
   const { user_id } = await verify.json()
   return user_id
 }
@@ -59,12 +59,12 @@ function Profile() {
   useEffect(() => {
     const fetchProfile = async () => {
       const idFromProtected = await getUserId()
-      if (!idFromProtected) {
+      if (idFromProtected === null) {
         navigate('/login')
         return
       }
 
-      setCurrentUserId(idFromProtected)
+      if (idFromProtected !== undefined) setCurrentUserId(idFromProtected)
 
       const id = userId || idFromProtected
 


### PR DESCRIPTION
## Summary
- tweak token refresh logic in `Feed` and `Profile`
- redirect to login only when refresh fails

## Testing
- `pip install -r auth_service/requirements.txt`
- `pip install aiosqlite`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ad075302483249b26a713b6b6ce41