### PR TITLE
Add profile photo display

### DIFF
--- a/frontend/src/Profile.css
+++ b/frontend/src/Profile.css
@@ -98,6 +98,14 @@ body {
     color: #555;
 }
 
+.photo-img {
+    width: 150px;
+    height: 150px;
+    object-fit: cover;
+    border-radius: 50%;
+    margin-bottom: 1rem;
+}
+
 .upload-btn {
     background-color: var(--primary-dark);
     color: white;

--- a/frontend/src/Profile.jsx
+++ b/frontend/src/Profile.jsx
@@ -61,6 +61,7 @@ function Profile() {
   const [editGender, setEditGender] = useState('male')
 
   const fileInputRef = useRef(null)
+  const [photoSrc, setPhotoSrc] = useState(null)
 
   useEffect(() => {
     const fetchProfile = async () => {
@@ -90,6 +91,11 @@ function Profile() {
         setAge(String(user_data.age || ''))
         setCity(user_data.city || '')
         setGender(user_data.gender || 'male')
+        if (user_data.file && user_data.mime_type) {
+          setPhotoSrc(`data:${user_data.mime_type};base64,${user_data.file}`)
+        } else {
+          setPhotoSrc(null)
+        }
 
         setEditName(user_data.name || '')
         setEditSurname(user_data.surname || '')
@@ -141,6 +147,7 @@ function Profile() {
         body: formData,
         credentials: 'include',
       })
+      setPhotoSrc(URL.createObjectURL(file))
     } catch (err) {
       console.error(err)
     }
@@ -213,7 +220,11 @@ function Profile() {
           <div className="profile-card">
             <div className="profile-photo">
               <div className="photo-placeholder">
-                <i className="fas fa-user-circle" />
+                {photoSrc ? (
+                  <img src={photoSrc} alt="avatar" className="photo-img" />
+                ) : (
+                  <i className="fas fa-user-circle" />
+                )}
               </div>
               {isOwnProfile && (
                 <>

--- a/profile_service/routers/profile.py
+++ b/profile_service/routers/profile.py
@@ -1,4 +1,5 @@
-from fastapi import APIRouter,HTTPException,Depends
+from fastapi import APIRouter, HTTPException, Depends
+import base64
 
 from profile_service.database.base import SessionDep
 from profile_service.utils.sql_request import get_user_id_profile, get_user_id_photo
@@ -19,9 +20,10 @@ async def profile(user_id : int):
         'gender': user.gender,
         'city': user.city,
         'age': user.age,
-        'file': user_photo.file,
-        "file_name": user_photo.file_name,
-        "mime_type": user_photo.mime_type
+        'file': base64.b64encode(user_photo.file).decode() if user_photo else None,
+        "file_name": user_photo.file_name if user_photo else None,
+        "mime_type": user_photo.mime_type if user_photo else None,
+        "file_size": user_photo.file_size if user_photo else None
 
 
     }


### PR DESCRIPTION
## Summary
- show user profile photo on the frontend
- include file size and encoded image in profile API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c1f5019c883249b955207c647e135