### PR TITLE
Align frontend endpoints with backend

### DIFF
--- a/frontend/src/Feed.jsx
+++ b/frontend/src/Feed.jsx
@@ -47,7 +47,7 @@ function Feed() {
   const [currentUserId, setCurrentUserId] = useState(null)
 
   const sendVisit = async () => {
-    await fetch('http://localhost:8002/visit_time', {
+    await fetch('http://localhost:8002/record_visit_time', {
       method: 'POST',
       credentials: 'include',
     })
@@ -61,7 +61,7 @@ function Feed() {
         return
       }
       if (id !== undefined) setCurrentUserId(id)
-      await fetch('http://localhost:8002/visit_time', {
+      await fetch('http://localhost:8002/record_visit_time', {
         method: 'POST',
         credentials: 'include',
       })

--- a/frontend/src/Login.jsx
+++ b/frontend/src/Login.jsx
@@ -45,7 +45,7 @@ function Login() {
       body: JSON.stringify({ login: username, password }),
     })
     if (response.ok) {
-      await fetch('http://localhost:8002/visit_time', {
+      await fetch('http://localhost:8002/record_visit_time', {
         method: 'POST',
         credentials: 'include',
       })

--- a/frontend/src/Profile.jsx
+++ b/frontend/src/Profile.jsx
@@ -41,7 +41,7 @@ function Profile() {
   const [status, setStatus] = useState('unactivate')
 
   const sendVisit = async () => {
-    await fetch('http://localhost:8002/visit_time', {
+    await fetch('http://localhost:8002/record_visit_time', {
       method: 'POST',
       credentials: 'include',
     })
@@ -115,10 +115,8 @@ function Profile() {
         setEditCity(user_data.city || '')
         setEditGender(user_data.gender || 'male')
         setNotFound(false)
-        const statusRes = await fetch('http://localhost:8002/check_time', {
+        const statusRes = await fetch(`http://localhost:8002/check_time?user_id=${id}`, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ user_id: id }),
         })
         if (statusRes.ok) {
           const { status } = await statusRes.json()

--- a/frontend/src/Registration.jsx
+++ b/frontend/src/Registration.jsx
@@ -35,7 +35,7 @@ function Registration() {
       }),
     })
     if (response.ok) {
-      await fetch('http://localhost:8002/visit_time', {
+      await fetch('http://localhost:8002/record_visit_time', {
         method: 'POST',
         credentials: 'include',
       })


### PR DESCRIPTION
## Summary
- update frontend visit_time requests to `/record_visit_time`
- send user_id as query param when hitting `/check_time`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6877831912408324b1a200d252aa257f